### PR TITLE
Fix SHA tag mismatch in QA deployment workflow

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -61,8 +61,9 @@ jobs:
           # Apply the QA configuration
           kubectl apply -k k8s/overlays/qa
 
-          # Update the image to the newly built one
-          kubectl set image deployment/javavulny javavulny=ghcr.io/${{ github.repository }}:main-${{ github.sha }} -n javavulny-qa
+          # Update the image to the newly built one (using short SHA to match metadata-action)
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          kubectl set image deployment/javavulny javavulny=ghcr.io/${{ github.repository }}:main-${SHORT_SHA} -n javavulny-qa
 
           # Wait for rollout to complete
           kubectl rollout status deployment/javavulny -n javavulny-qa --timeout=5m
@@ -115,9 +116,10 @@ jobs:
 
       - name: Deployment summary
         run: |
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
           echo "## QA Deployment Successful :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Environment:** QA" >> $GITHUB_STEP_SUMMARY
           echo "**URL:** ${{ steps.qa-url.outputs.qa_host }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** ghcr.io/${{ github.repository }}:main-${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** ghcr.io/${{ github.repository }}:main-${SHORT_SHA}" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The docker/metadata-action creates short SHA tags (7 chars) by default, but the deployment was trying to use the full 40-char SHA. This caused image pull failures in Kubernetes.

Updated to extract and use short SHA to match the actual tags being created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)