### PR TITLE
Break builds in QA on new vulns

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -101,7 +101,7 @@ jobs:
           NO_COLOR: true
           NO_PROGRESS: true
           SARIF_ARTIFACT: true
-        continue-on-error: true
+        continue-on-error: false
         uses: stackhawk/hawkscan-action@v2
         with:
           apiKey: ${{ secrets.HAWK_API_KEY }}


### PR DESCRIPTION
Allow HawkScan to break the build if it finds new vulnerabilities.